### PR TITLE
Move baseUrl definition out of preprocessor conditional block in finetune download launcher

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1310,8 +1310,9 @@ void MainWindow::runFinetune(const QString &filename) {
     return;
 #endif
 
-#ifdef APP_EXTRA
     const QString baseUrl = QLatin1String("https://") + Constants::ORG_DOMAIN;
+
+#ifdef APP_EXTRA
     const QString filesUrl = baseUrl + QLatin1String("/files/");
     QString url = filesUrl + "finetune/finetune.";
 


### PR DESCRIPTION
This fixes a compilation error where baseUrl was reference but not declared (e.g. if `!defined(APP_EXTRA)`).