### PR TITLE
Fixes breaking build on ChromeOS and likely other platforms

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1330,6 +1330,7 @@ void MainWindow::runFinetune(const QString &filename) {
     dialog->show();
 
 #else
+    const QString baseUrl = QLatin1String("https://") + Constants::ORG_DOMAIN;
     QString url = baseUrl + QLatin1String("/finetune");
     QDesktopServices::openUrl(url);
 #endif


### PR DESCRIPTION
Fix a variable declaration build error if APP_EXTRA is not set. Not familiar with the codebase so I don't know what this does, but wanted to try out Musique. This fixed my build, so dropping it here in case it helps. Enjoy!