### PR TITLE
fix: compatibility with TagLib 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Translations are done at https://www.transifex.com/flaviotordini/musique/
 Just register and apply for a language team. Please don't request translation merges on GitHub.
 
 ## Build instructions
-To compile Musique you need at least Qt 6.0. The following Qt modules are needed: core, gui, widgets, network, sql (using the Sqlite plugin), declarative, dbus. You also need TagLib: http://taglib.github.io and MPV >= 0.29.0: https://mpv.io/
+To compile Musique you need at least Qt 6.0. The following Qt modules are needed: core, gui, widgets, network, sql (using the Sqlite plugin), declarative, dbus. You also need TagLib: http://taglib.github.io >= 1.10 and MPV >= 0.29.0: https://mpv.io/
 
 To be able to build on a Debian (or derivative) system:
 

--- a/src/coverutils.cpp
+++ b/src/coverutils.cpp
@@ -158,7 +158,7 @@ bool CoverUtils::coverFromMP4(const QString &filename, Album *album) {
     TagLib::MP4::Tag *tag = static_cast<TagLib::MP4::Tag *>(f.tag());
     if (!tag) return false;
 
-    TagLib::MP4::ItemListMap itemsListMap = tag->itemListMap();
+    TagLib::MP4::ItemMap itemsListMap = tag->itemMap();
     TagLib::MP4::Item coverItem = itemsListMap["covr"];
     TagLib::MP4::CoverArtList coverArtList = coverItem.toCoverArtList();
     TagLib::MP4::CoverArt coverArt = coverArtList.front();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,9 @@ $END_LICENSE */
 #include "views.h"
 #include "zoomableui.h"
 
+#include <iostream>
+
+
 #if defined(APP_MAC_SEARCHFIELD) && !defined(APP_MAC_QMACTOOLBAR)
 #include "searchlineedit_mac.h"
 #else

--- a/src/tags/mp4utils.h
+++ b/src/tags/mp4utils.h
@@ -9,7 +9,7 @@
 namespace Mp4Utils {
 
 void load(TagLib::MP4::Tag *tag, Tags *tags) {
-    const TagLib::MP4::ItemListMap &map = tag->itemListMap();
+    const TagLib::MP4::ItemMap &map = tag->itemMap();
 
     if (map.contains("trkn")) {
         TagLib::MP4::Item::IntPair intPair = map["trkn"].toIntPair();
@@ -31,7 +31,7 @@ void load(TagLib::MP4::Tag *tag, Tags *tags) {
         tags->setComposerSort(v);
     }
 
-    TagLib::MP4::ItemListMap::ConstIterator it = map.find("aART");
+    TagLib::MP4::ItemMap::ConstIterator it = map.find("aART");
     if (it != map.end()) {
         TagLib::StringList sl = it->second.toStringList();
         if (!sl.isEmpty())


### PR DESCRIPTION
This PR provides compatibility with TagLib 2.0 by changing from a previously deprecated API to the already available replacement.

- replace `MP4::ItemListMap` by `TagLib::MP4::ItemMap`
- replace `MP4::Tag::itemListMap()` by `MP4::Tag::itemMap()`
- add version requirement for TagLib >= 1.10 in `README.md`
- add an include for `iostream` in `mainWindow.cpp` to be sure that `std::cout` is available.

The new API type and function have been added to TagLib with version 1.10 on 04.12.2015. The change to the new API therefore does not break building `musique` with any TagLib version >= 1.10.

The missing include for `iostream` led to a compile error on openSUSE Leap 15.5. It may depend on the environment whether this is necessary, but it is anyway good practice to include this explicitly when it is used in the compile unit.

closes #53